### PR TITLE
Fix defined legacy packages

### DIFF
--- a/bye-bye-jetifier/src/main/java/com/dipien/byebyejetifier/ByeByeJetifierExtension.kt
+++ b/bye-bye-jetifier/src/main/java/com/dipien/byebyejetifier/ByeByeJetifierExtension.kt
@@ -5,6 +5,7 @@ open class ByeByeJetifierExtension {
     var legacyGroupIdPrefixes: List<String> = listOf("android.arch", "com.android.support")
 
     // https://developer.android.com/jetpack/androidx/migrate/class-mappings#androidsupport
+    // https://github.com/androidx/androidx/blob/androidx-master-dev/jetifier/jetifier/migration.config
     var legacyPackagesPrefixes: List<String> = listOf(
         "android.arch",
         "android.support",


### PR DESCRIPTION
I got the prefixes from "restrictToPackagePrefixes" variable defined in Jetifier:
https://github.com/androidx/androidx/blob/androidx-master-dev/jetifier/jetifier/migration.config